### PR TITLE
Use Uname as fallback if Uid is not supplied when Dotu is enabled.

### DIFF
--- a/srv/fcall.go
+++ b/srv/fcall.go
@@ -65,7 +65,7 @@ func (srv *Srv) auth(req *Req) {
 	}
 
 	var user ninep.User = nil
-	if tc.Unamenum != ninep.NOUID || conn.Dotu {
+	if tc.Unamenum != ninep.NOUID && conn.Dotu {
 		user = srv.Upool.Uid2User(int(tc.Unamenum))
 	} else if tc.Uname != "" {
 		user = srv.Upool.Uname2User(tc.Uname)
@@ -121,7 +121,7 @@ func (srv *Srv) attach(req *Req) {
 	}
 
 	var user ninep.User = nil
-	if tc.Unamenum != ninep.NOUID || conn.Dotu {
+	if tc.Unamenum != ninep.NOUID && conn.Dotu {
 		user = srv.Upool.Uid2User(int(tc.Unamenum))
 	} else if tc.Uname != "" {
 		user = srv.Upool.Uname2User(tc.Uname)


### PR DESCRIPTION
As per http://ericvh.github.io/9p-rfc/rfc9p2000.u.html#anchor16.

In the current case when 9P2000.u is used and uid = ~0, we will not find a user, even though the fallback uname should be used.
